### PR TITLE
Fix subscription cleanup to prevent zombie subscriptions

### DIFF
--- a/src/main/java/org/iris_events/subscription/SubscriptionManager.java
+++ b/src/main/java/org/iris_events/subscription/SubscriptionManager.java
@@ -19,7 +19,7 @@ public class SubscriptionManager {
         this.subscriptionCollection = subscriptionCollection;
     }
 
-    @Scheduled(every = "PT12H")
+    @Scheduled(every = "${subscription.cleanup.interval}")
     public void cleanup() {
         this.subscriptionCollection.cleanUp();
     }

--- a/src/main/java/org/iris_events/subscription/collection/Utils.java
+++ b/src/main/java/org/iris_events/subscription/collection/Utils.java
@@ -9,6 +9,11 @@ public class Utils {
     public static final String RESOURCE_SNAP_TEMPLATE = "resTypeResIdSnap|%s";
     public static final String RESOURCE_SUB_TEMPLATE = "resTypeResIdSub|%s";
     public static final String PIPE = "|";
+    public static final String SUBSCRIPTION_ID_DELIMITER = "\\|";
+    public static final int MIN_SUBSCRIPTION_PARTS = 4;
+    public static final int RESOURCE_TYPE_INDEX = 2;
+    public static final int RESOURCE_ID_INDEX = 3;
+
 
     public static String getResourceSubscriptionsSetId(final String resourceType, final String resourceId) {
         final var uniqueResId = getUniqueResId(resourceType, resourceId);
@@ -31,5 +36,15 @@ public class Utils {
     public static String generateSubscriptionId(Subscription subscription) {
         final var subId = subscription.sessionId() + PIPE + subscription.resourceType() + PIPE + subscription.resourceId();
         return String.format(SUB_TEMPLATE, subId);
+    }
+
+    public static boolean isValidSubscriptionId(String subscriptionId) {
+        return subscriptionId != null &&
+                subscriptionId.split(SUBSCRIPTION_ID_DELIMITER).length >= MIN_SUBSCRIPTION_PARTS;
+    }
+
+    public static String getResourceSetKey(String subscriptionId) {
+        String[] parts = subscriptionId.split(SUBSCRIPTION_ID_DELIMITER);
+        return Utils.getResourceSubscriptionsSetId(parts[RESOURCE_TYPE_INDEX], parts[RESOURCE_ID_INDEX]);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,7 @@ subscription.collection.redis.ttl=86400
 subscription.cleanup.interval=${SUBS_CLEAN_INTERVAL:PT10M}
 
 quarkus.otel.exporter.otlp.traces.endpoint=${OTLP_ENDPOINT:http://localhost:4318}
-quarkus.otel.exporter.otlp.traces.protocol=http/protobuf
+quarkus.otel.exporter.otlp.traces.protocol=${OTLP_PROTOCOL:http/protobuf}
 quarkus.otel.enabled=false
 %prod.quarkus.otel.enabled=true
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,7 @@ quarkus.health.openapi.included=true
 
 # SUBSCRIPTION COLLECTION REDIS
 subscription.collection.redis.ttl=86400
+subscription.cleanup.interval=${SUBS_CLEAN_INTERVAL:PT10M}
 
 quarkus.otel.exporter.otlp.traces.endpoint=${OTLP_ENDPOINT:http://localhost:4318}
 quarkus.otel.exporter.otlp.traces.protocol=http/protobuf


### PR DESCRIPTION
 When WebSocket connections closed under high traffic, subscriptions weren't cleaned up immediately after closing the session. This created "zombie subscriptions" that accumulated in Redis.
 
  - **Immediate cleanup:** Remove subscriptions instantly when connections close using batched Redis operations
  - **Configurable safety net**: Keep periodic cleanup (now every 10 minutes) to catch any missed orphans
  - **Performance improvement**: Eliminates need to scan/filter large subscription sets
